### PR TITLE
WIP: Spin back up docs.gitops.weave.works

### DIFF
--- a/spin.toml
+++ b/spin.toml
@@ -1,10 +1,10 @@
 spin_manifest_version = 2
 
 [application]
-name = "docs"
+name = "docs-gitops-weave"
 version = "0.1.0"
 authors = ["Kingdon P Barrett <kingdon@tuesdaystudios.com>"]
-description = "docs.gitops"
+description = "docs.gitops.weave.works"
 
 [[trigger.http]]
 # route = "/static/..."


### PR DESCRIPTION
This is live now at https://gitops.weave.works

I am not sure we have a way to address 4-level domain like docs.gitops.... I believe Charles is working it out with Cloudflare

This is not for merge, it's just using instead the app id `docs-gitops-weave` versus `docs` that we used for https://docs.microscaler.com